### PR TITLE
Update dependencies so tests complete

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ docutils==0.14
 flake8==3.5.0
 Pygments==2.2.0
 pyobjc-core==4.1 ; sys_platform == 'darwin'
+pytest==5.4.2
 pytest-cov==2.5.1
-pytest==3.3.1
-pyyaml==3.12
+PyYAML==5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pyobjc-core==4.1 ; sys_platform == 'darwin'
 pytest-cov==2.5.1
 pytest==5.4.2 ; python_version > "3.4"
 PyYAML==5.3.1 ; python_version > "3.4"
-pytest==3.3.1 ; python_version <= "3.4"
+pytest==4.6.10 ; python_version <= "3.4"
 pyyaml==3.12  ; python_version <= "3.4"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@ docutils==0.14
 flake8==3.5.0
 Pygments==2.2.0
 pyobjc-core==4.1 ; sys_platform == 'darwin'
-pytest==5.4.2
 pytest-cov==2.5.1
-PyYAML==5.3.1
+pytest==5.4.2 ; python_version > "3.4"
+PyYAML==5.3.1 ; python_version > "3.4"
+pytest==3.3.1 ; python_version <= "3.4"
+pyyaml==3.12  ; python_version <= "3.4"
+


### PR DESCRIPTION
These small changes to the requirements.txt are needed so it references modern buildable versions of the dependencies.

This tests with no errors or warnings on py3.5 and py3.6. On Python 3.7 There a deprecation earing related to changes in the abc module.